### PR TITLE
Demo Scene open from MainMenu

### DIFF
--- a/Assets/Scenes/Demo Scene.unity
+++ b/Assets/Scenes/Demo Scene.unity
@@ -322,6 +322,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 729320505}
+  - {fileID: 526558495}
   - {fileID: 1649168265}
   - {fileID: 469019602}
   m_Father: {fileID: 0}
@@ -575,7 +576,7 @@ Transform:
   - {fileID: 1327746323}
   - {fileID: 6180979}
   m_Father: {fileID: 368704289}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &485849271
 GameObject:
@@ -795,6 +796,56 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!1 &526558494
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 526558495}
+  - component: {fileID: 526558496}
+  m_Layer: 0
+  m_Name: '[SceneLoader]'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &526558495
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526558494}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 368704289}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &526558496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 526558494}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dad2dd83643e3c34bad9e51a345db2ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerPrefab: {fileID: 2646993275326716545, guid: 4154d57994558ff489a9180c3151e624, type: 3}
+  playerObject: {fileID: 0}
+  firstBossObject: {fileID: 0}
+  firstBossKilled: 0
+  savePointsParent: {fileID: 469019601}
+  savePoints: []
+  respawnPoint: {x: 0, y: 0}
 --- !u!1 &545968650
 GameObject:
   m_ObjectHideFlags: 0
@@ -1147,7 +1198,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 368704289}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1933420239
 GameObject:

--- a/Assets/Scripts/JereT/DemoLoader.cs
+++ b/Assets/Scripts/JereT/DemoLoader.cs
@@ -1,0 +1,125 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class DemoLoader : MonoBehaviour
+{
+    public static DemoLoader levelLoaderInstance;
+
+    [Header("Player Objects")]
+    public GameObject playerPrefab;
+    public GameObject playerObject;
+
+    [Header("Boss Objects")]
+    public GameObject firstBossObject;
+    public bool firstBossKilled;
+
+    [Header("Savepoints")]
+    public GameObject savePointsParent;
+    [SerializeField] private List<GameObject> savePoints = new List<GameObject>();
+    [SerializeField] private Vector2 respawnPoint;
+
+    /*
+     * GameScene loads initialize player and bosses
+     */
+    private void Start()
+    {
+        levelLoaderInstance = this;
+        if (GameStatus.status != null)
+        {
+            // SCENE INITIALIZATION --- could be done in Awake too test which is better
+            Debug.Log("Binds for save tests(alpha keys): 0 save, 9 checksave, 8 delete, 7 load, O respawn, P kill boss");
+            Debug.Log("Player spawning to: " + GameStatus.status.getLoadedData().position[0] + ", " + GameStatus.status.getLoadedData().position[1]);
+            if (GameObject.Find("Player").activeInHierarchy)
+            {
+                playerObject = GameObject.Find("Player");
+                playerObject.transform.position = new Vector2(GameStatus.status.getLoadedData().position[0], GameStatus.status.getLoadedData().position[1]);
+            }
+            else
+            {
+                playerObject = Respawn(playerPrefab, new Vector2(GameStatus.status.getLoadedData().position[0], GameStatus.status.getLoadedData().position[1]));
+            }
+
+            if (firstBossObject != null && GameStatus.status.getLoadedData().bossesDefeated[0] == true)
+            {
+                Destroy(firstBossObject);
+                firstBossKilled = GameStatus.status.getLoadedData().bossesDefeated[0];
+            }
+
+            // Make list of savePoints
+            for (int i = 0; i < savePointsParent.transform.childCount; i++)
+            {
+                savePoints.Add(savePointsParent.transform.GetChild(i).gameObject);
+            }
+        }
+        else
+        {
+            Debug.Log("No GameStatus object in scene if testing: either start from MainMenu or drag player prefab to scene");
+        }
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+        // Later from interaction
+        if (Input.GetKeyDown(KeyCode.Alpha0))
+        {
+            Save();
+        }
+
+
+        // FOR DEBUGGING -- Kill BOSS
+        if (Input.GetKeyDown(KeyCode.P))
+        {
+            Debug.Log("Instakill bouss");
+            Destroy(firstBossObject);
+            firstBossKilled = true;
+        }
+        // FOR DEBUGGING -- Respawn 
+        if (Input.GetKeyDown(KeyCode.O))
+        {
+            Debug.Log("Respawning, atm loading scene with loaded save");
+            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+        }
+    }
+
+    public void Save()
+    {
+        if (CheckIfPlayerAtSavePoint())
+        {
+            // Here update dataToSave 
+            GameStatus.status.UpdatePlayerPosition(respawnPoint.x, respawnPoint.y);
+
+            GameStatus.status.UpdateBossKilled(0, firstBossKilled);
+
+            GameStatus.status.Save();
+        }
+        else
+        {
+            Debug.Log("Not close to any savePoint");
+        }
+    }
+
+    /*
+     * Checks if player has activated TriggerEnter on any savepoint to allow saving
+     */
+    private bool CheckIfPlayerAtSavePoint()
+    {
+        foreach (GameObject savePoint in savePoints)
+        {
+            if (savePoint.GetComponent<SavePoint>().getPlayerIsClose() == true)
+            {
+                respawnPoint = new Vector2(savePoint.transform.position.x, savePoint.transform.position.y);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public GameObject Respawn(GameObject obj, Vector2 pos)
+    {
+        return Instantiate(obj, pos, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/JereT/DemoLoader.cs.meta
+++ b/Assets/Scripts/JereT/DemoLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dad2dd83643e3c34bad9e51a345db2ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MenuScripts/MainMenuController.cs
+++ b/Assets/Scripts/MenuScripts/MainMenuController.cs
@@ -55,7 +55,10 @@ public class MainMenuController : MonoBehaviour
             //Aloitetaan peli alusta.
             Debug.Log("New game started.");
 
-            StartCoroutine(LoadAsynchronously(1));
+            // Opening Main Game Scene
+            //StartCoroutine(LoadAsynchronously(1));
+            // Opening demo scene
+            StartCoroutine(LoadAsynchronously(SceneManager.sceneCountInBuildSettings - 1));
         }
         
     }
@@ -67,7 +70,10 @@ public class MainMenuController : MonoBehaviour
         // Load completed no errors
         if (GameStatus.status.Load() == true)
         {
-            StartCoroutine(LoadAsynchronously(1));
+            // Opening Main Game Scene
+            //StartCoroutine(LoadAsynchronously(1));
+            // Opening demo scene
+            StartCoroutine(LoadAsynchronously(SceneManager.sceneCountInBuildSettings - 1));
         }
         // Loading had errors don't open scene
         else

--- a/Assets/Scripts/Saving/SavePoint.cs
+++ b/Assets/Scripts/Saving/SavePoint.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class SavePoint : Interactable
 {
@@ -27,9 +28,18 @@ public class SavePoint : Interactable
     public override void Interact()
     {
         Debug.Log("Saving game with interaction...");
-        Level01Loader.levelLoaderInstance.Save();    
-        
-        // aseta pelaajan hp
+
+        // Main Game Scene
+        if (SceneManager.GetActiveScene().name.Contains("01"))
+        {
+            Level01Loader.levelLoaderInstance.Save();
+        }
+        if (SceneManager.GetActiveScene().name.Contains("Demo"))
+        {
+            DemoLoader.levelLoaderInstance.Save();
+        }
+
+
     }
 
     public bool getPlayerIsClose()

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -14,5 +14,8 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/JereTestSpace.unity
     guid: 5e9278d401f088746bb019a8b6fd4131
+  - enabled: 1
+    path: Assets/Scenes/Demo Scene.unity
+    guid: 08a9a117af9403a47a0edacb5353cfc8
   m_configObjects:
     com.unity.input.settings: {fileID: 11400000, guid: 8f60441de0f6e314cb382bdc2a273247, type: 2}


### PR DESCRIPTION
Fixed saving.
Game Scene where playing actually happens needs GameStatus object and LevelLoader for saving.
- GameStatus is intantiated as dontdestroyonload in MainMenu atm and carries to scene that is opened via MainMenu new game or continue buttons(instantiations should't really be anywhere else).
- LevelLoader is Scene specific object/script that handles, receives and sends data to GameStatus for saving and loading. Examples of data: player pos, what bosses killed, what abilites unlocked etc.