### PR TITLE
Shockwave Tool - Jumping Bug Fixes

### DIFF
--- a/Assets/Scenes/ShockwaveTool.unity
+++ b/Assets/Scenes/ShockwaveTool.unity
@@ -17537,11 +17537,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2049820520096467095, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.x
-      value: 0.9766512
+      value: -0.9909878
       objectReference: {fileID: 0}
     - target: {fileID: 2049820520096467095, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.y
-      value: -0.0000004556252
+      value: -0.004522026
       objectReference: {fileID: 0}
     - target: {fileID: 2049820520137079200, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_RootOrder
@@ -17674,7 +17674,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2646993275326716549, guid: 4154d57994558ff489a9180c3151e624, type: 3}
       propertyPath: allowShockwaveJump
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2646993275326716551, guid: 4154d57994558ff489a9180c3151e624, type: 3}
       propertyPath: shockwaveTool

--- a/Assets/Scenes/ShockwaveTool.unity
+++ b/Assets/Scenes/ShockwaveTool.unity
@@ -12281,13 +12281,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1851797149}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
   m_LocalPosition: {x: 0, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1940316767}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
 --- !u!199 &1851797151
 ParticleSystemRenderer:
   serializedVersion: 6
@@ -12490,7 +12490,7 @@ ParticleSystem:
     startSpeed:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 10
+      scalar: 5
       minScalar: 5
       maxCurve:
         serializedVersion: 2
@@ -17278,11 +17278,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ee9fc14155c80040934ee30f8cd0ccf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  jumpForce: 22
   usageCooldown: 1
-  playerScript: {fileID: 2646993275714197190}
-  rb: {fileID: 1859845175}
-  shockwaveDirection: {fileID: 1691313836}
   shockwaveJumpEffect: {fileID: 212109729}
   shockwaveDiveEffect: {fileID: 1851797152}
   shockwaveAttackEffect: {fileID: 1691313839}
@@ -17517,11 +17513,11 @@ PrefabInstance:
       objectReference: {fileID: 729320505}
     - target: {fileID: 284613507, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.x
-      value: -0.9967248
+      value: -0.9933515
       objectReference: {fileID: 0}
     - target: {fileID: 284613507, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.y
-      value: -1.558608e-19
+      value: -0.1229284
       objectReference: {fileID: 0}
     - target: {fileID: 505850491, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_Follow
@@ -17537,11 +17533,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2049820520096467095, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.x
-      value: -0.9909878
+      value: 0.9847379
       objectReference: {fileID: 0}
     - target: {fileID: 2049820520096467095, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.y
-      value: -0.004522026
+      value: -0.05335687
       objectReference: {fileID: 0}
     - target: {fileID: 2049820520137079200, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scripts/Equipment/Shield.cs
+++ b/Assets/Scripts/Equipment/Shield.cs
@@ -10,10 +10,12 @@ public class Shield : MonoBehaviour
     public float ProtectionAmount { get; private set; }
 
     [SerializeField] private GameObject shield;
+
+    [Header("Shield variables")]
     [SerializeField] private float protectionValue;
     [SerializeField] private float parryTimeWindow = 0.5f;
    
-    private bool hitParried = false;
+    private bool hitParried = false; // State variable for tracking successful parries
     private float nextParry = -1; // Initialize as -1. First time it will always be less than the current time and will allow to parry. 
     private float parryCooldown = 0.6f;
 
@@ -28,19 +30,16 @@ public class Shield : MonoBehaviour
         // Blocking
         if (context.started && (Time.time >= nextParry || hitParried))
         {
-            nextParry = Time.time + parryCooldown;
-            hitParried = false;
-
+            nextParry = Time.time + parryCooldown; // Sets a time when parry can be used again
+            hitParried = false; // Reset hitParried state
+            shield.SetActive(true); // Activate shield graphics
             Blocking = true;
-            shield.SetActive(true);
         }
         // Blocking cancelled
         if (context.canceled)
         {
-            // Parry window activated
-            StartCoroutine(ActivateParryWindow());
-
-            shield.SetActive(false);
+            StartCoroutine(ActivateParryWindow()); // Parry window activated
+            shield.SetActive(false); // Disable shield graphics
             Blocking = false;
         }
     }

--- a/Assets/Scripts/Equipment/ShockwaveTool.cs
+++ b/Assets/Scripts/Equipment/ShockwaveTool.cs
@@ -9,60 +9,22 @@ public class ShockwaveTool : MonoBehaviour
     public bool ShockwaveAttackUsed { get; set; }
 
     [Header("Shockwave parameters")]
-    [SerializeField] private float jumpForce;
     [SerializeField] private float usageCooldown;
 
     [Header("References")]
-    [SerializeField] private Player playerScript;
-    [SerializeField] private Rigidbody2D rb;
-    [SerializeField] private GameObject shockwaveDirection;
     [SerializeField] private ParticleSystem shockwaveJumpEffect;
     [SerializeField] private ParticleSystem shockwaveDiveEffect;
     [SerializeField] private ParticleSystem shockwaveAttackEffect;
 
     private float nextShockwave = -1; // Initialize as -1. First time it will always be less than the current time so use it can be used. 
 
-    private void Update()
-    {
-        UpdateDirection();
-    }
-
-    private void UpdateDirection()
-    {
-        // NEW WAY WITH ONLY HORIZONTAL INPUT
-
-        // When not shockwave jumping or diving
-        float horizontal = playerScript.IsFacingRight() ? 1 : -1;
-        shockwaveDirection.transform.localPosition = new Vector3(0, 0, 0);
-        shockwaveDirection.transform.rotation = Quaternion.Euler(0, 0, -90 * horizontal);
-
-        /* OLD WAY WITH VERTICAL INPUT
-        float vertical = playerScript.InputVertical;
-        switch (vertical)
-        {
-            case 0:
-                float horizontal = playerScript.IsFacingRight() ? 1 : -1;
-                shockwaveDirection.transform.localPosition = new Vector3(0, 0, 0);
-                shockwaveDirection.transform.rotation = Quaternion.Euler(0, 0, -90 * horizontal);
-                break;
-            case -1:
-                shockwaveDirection.transform.localPosition = new Vector3(-1.5f, -1, 0);
-                shockwaveDirection.transform.rotation = Quaternion.Euler(0, 0, 180);
-                break; // DIVE
-            case 1: 
-                shockwaveDirection.transform.localPosition = new Vector3(-1.5f, -1, 0);
-                shockwaveDirection.transform.rotation = Quaternion.Euler(0, 0, 0);
-                break; // JUMP
-        }
-        */
-    }
-
-    // Shockwave Jump: Triggered when double jumping
+    // Shockwave Jump: Triggered from PlayerMovement when double jumping
     public void ShockwaveJump() // Context tells the function when the action is triggered
     {
         shockwaveJumpEffect.Play();
     }
 
+    // Shockwave Dive: Triggered from PlayerMovement when activating dive
     public void ShockwaveDive()
     {
         shockwaveDiveEffect.Play();
@@ -73,27 +35,13 @@ public class ShockwaveTool : MonoBehaviour
     {
         if (context.started && Time.time >= nextShockwave)
         {
-            nextShockwave = Time.time + usageCooldown;
+            nextShockwave = Time.time + usageCooldown; // Sets a time when attack can be used again
             shockwaveAttackEffect.Play();
 
             // Shockwave attack functionality here
 
             StartCoroutine(ActivateAttackCooldown(usageCooldown));
         }
-    }
-
-    private IEnumerator ActivateJumpCooldown(float cooldownTime)
-    {
-        ShockwaveJumpUsed = true;
-
-        float cdTimer = 0;
-        while (cdTimer <= cooldownTime)
-        {
-            cdTimer += Time.deltaTime;
-            yield return new WaitForEndOfFrame();
-        }
-
-        ShockwaveJumpUsed = false;
     }
 
     private IEnumerator ActivateAttackCooldown(float cooldownTime)

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
+// This script can be used to control all player sub scripts through one place.
+// Holds player components and state variables that can be accessed from anywhere
 public class Player : MonoBehaviour
 {
     public float InputHorizontal { get; private set; }
@@ -10,11 +12,6 @@ public class Player : MonoBehaviour
 
     private GUIStyle TextStyleEnergy = new GUIStyle();
     private GUIStyle TextStyleHealth = new GUIStyle();
-    // This script can be used to control all player sub scripts through one place.
-    // Holds player components and state variables that can be accessed from anywhere
-
-    // This script could maybe become useful when starting to make animation controller. 
-    // But maybe even then a separate animation controller script could be enough by itself.
 
     [Header("Player Sub Scripts")]
     [SerializeField] private PlayerMovement movementScript;
@@ -54,8 +51,6 @@ public class Player : MonoBehaviour
     {
         GUI.Label(new Rect(10, 10, 300, 100), "Health: " + healthScript.GetHealth(), TextStyleHealth);
         GUI.Label(new Rect(200, 10, 300, 100), "Energy: " + energyScript.GetEnergy(), TextStyleEnergy);
-        GUI.Label(new Rect(400, 10, 300, 100), "Horizontal: " + InputHorizontal, TextStyleHealth);
-        GUI.Label(new Rect(600, 10, 300, 100), "Vertical: " + InputVertical, TextStyleEnergy);
     }
 
     // Move action: Called when the Move Action Button is pressed

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -125,6 +125,7 @@ public class PlayerMovement : MonoBehaviour
                 rb.velocity = new Vector2(0, 0); // Set velocity here to zero else movement bugs while climbing
 
                 canMove = false; // Prevent moving while climbing mostly for animations
+                canShockwaveJump = false;
 
                 lastTimeClimbed = Time.time; // We start climbing set time here
 
@@ -201,7 +202,7 @@ public class PlayerMovement : MonoBehaviour
 
     private void CheckShockwaveJump()
     {
-        canShockwaveJump = (IsGrounded() && !shockwaveTool.ShockwaveJumpUsed) ? false : true;
+        canShockwaveJump = (!IsGrounded() && !isClimbing && !shockwaveTool.ShockwaveJumpUsed) ? true : false;
 
         if (!shockwaveTool.ShockwaveJumpUsed)
             shockwaveJumping = false;
@@ -298,7 +299,8 @@ public class PlayerMovement : MonoBehaviour
         }
 
         // Shockwave jump while in air
-        else if (context.started && allowShockwaveJump && canShockwaveJump && !shockwaveJumping)
+        else if (context.started && allowShockwaveJump && canShockwaveJump && !shockwaveJumping
+            && !(Time.time - lastGroundedTime <= coyoteTime)) // Check if coyote time is online
         {
             shockwaveTool.ShockwaveJump();
             rb.velocity = new Vector2(rb.velocity.x, jumpForce);


### PR DESCRIPTION
**Features:**
1) Fixed the bug where player could double jump while climbing, resulting in a massive jump. Fixed by disabling double jumps while climbing.

2) Fixed the bug where instead of jumping normally with coyote time, the double jump would activate. Fixed by disabling double jumps while coyote time is active.

3) Improved documentation on the scripts handling double jumping with Shockwave Tool.