### PR TITLE
Player animations melee fixes

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -10143,7 +10143,6 @@ MonoBehaviour:
   isFacingRight: 1
   canReceiveInputMove: 0
   canReceiveInputJump: 0
-  jumpInputReceived: 0
 --- !u!114 &2646993275326716546
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10506,6 +10505,7 @@ MonoBehaviour:
   playerPullForce: 750
   kbOnLight: 1
   kbOnLightLast: 1
+  comboCooldownTime: 0.5
   enemyLayer:
     serializedVersion: 2
     m_Bits: 128

--- a/Assets/Scripts/Player/AnimatorScripts/JumpScript.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/JumpScript.cs
@@ -34,19 +34,6 @@ public class JumpScript : StateMachineBehaviour
                 Player.Instance.SetCurrentState(Player.State.Ascending);
             }
         }
-
-
-        // From jumping or falling to Light attack
-        if (PlayerCombat.Instance.meleeInputReceived && !PlayerCombat.Instance.heavyHold)
-        {
-            Player.Instance.animator.Play("LAttack1");
-        }
-
-        // Throw
-        if (PlayerCombat.Instance.throwInputReceived)
-        {
-            animator.Play("Throw");
-        }
     }
 
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state

--- a/Assets/Scripts/Player/AnimatorScripts/LAttack1Script.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/LAttack1Script.cs
@@ -7,9 +7,6 @@ public class LAttack1Script : StateMachineBehaviour
     // OnStateEnter is called when a transition starts and the state machine starts to evaluate this state
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        // Set this to false so when we enter LTran1 we can start LAttack2 if we press melee button
-        // If not set here melee continues until this is set false
-        PlayerCombat.Instance.meleeInputReceived = false;
         // Set state to Player.cs
         Player.Instance.SetCurrentState(Player.State.Attacking);
         // Set bool for controller we are currently attacking includes LAttack1 and LTran1
@@ -27,6 +24,10 @@ public class LAttack1Script : StateMachineBehaviour
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
+        // Set this to false so when we enter LTran1 we can start LAttack2 if we press melee button
+        // If not set here melee continues until this is set false
+        PlayerCombat.Instance.meleeInputReceived = false;
+
         // Deal damage when we hit enemy
         PlayerCombat.Instance.DealDamage(1, false);
 

--- a/Assets/Scripts/Player/AnimatorScripts/LAttack2Script.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/LAttack2Script.cs
@@ -7,8 +7,6 @@ public class LAttack2Script : StateMachineBehaviour
     // OnStateEnter is called when a transition starts and the state machine starts to evaluate this state
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        PlayerCombat.Instance.meleeInputReceived = false;
-
         Player.Instance.SetCurrentState(Player.State.Attacking);
 
         animator.SetBool("isAttacking", true);
@@ -25,6 +23,8 @@ public class LAttack2Script : StateMachineBehaviour
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
+        PlayerCombat.Instance.meleeInputReceived = false;
+
         PlayerCombat.Instance.DealDamage(2, false);
 
         animator.SetBool("isAttacking", false);

--- a/Assets/Scripts/Player/AnimatorScripts/LAttack3Script.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/LAttack3Script.cs
@@ -7,8 +7,6 @@ public class LAttack3Script : StateMachineBehaviour
     // OnStateEnter is called when a transition starts and the state machine starts to evaluate this state
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        PlayerCombat.Instance.meleeInputReceived = false;
-
         Player.Instance.SetCurrentState(Player.State.Attacking);
 
         animator.SetBool("isAttacking", true);
@@ -25,6 +23,8 @@ public class LAttack3Script : StateMachineBehaviour
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
+        PlayerCombat.Instance.meleeInputReceived = false;
+
         PlayerCombat.Instance.DealDamage(3, false);
 
         animator.SetBool("isAttacking", false);

--- a/Assets/Scripts/Player/AnimatorScripts/LTran1Script.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/LTran1Script.cs
@@ -9,16 +9,16 @@ public class LTran1Script : StateMachineBehaviour
     {
         // Set transition state
         Player.Instance.SetCurrentState(Player.State.AttackTransition);
+
+        // Tell combat script of last attacks comboIndex LTran1 = (1) and lenght of this animationclip
+        PlayerCombat.Instance.UpdateCombo(1, animator.GetCurrentAnimatorStateInfo(0).length);
     }
 
     // OnStateUpdate is called on each Update frame between OnStateEnter and OnStateExit callbacks
-    override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
-    {
-        if (PlayerCombat.Instance.meleeInputReceived && !PlayerCombat.Instance.heavyHold && !animator.GetBool("isClimbing"))
-        {
-            Player.Instance.animator.Play("LAttack2");
-        }
-    }
+    //override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+
+    //}
 
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
     //override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)

--- a/Assets/Scripts/Player/AnimatorScripts/LTran2Script.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/LTran2Script.cs
@@ -8,16 +8,15 @@ public class LTran2Script : StateMachineBehaviour
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         Player.Instance.SetCurrentState(Player.State.AttackTransition);
+
+        PlayerCombat.Instance.UpdateCombo(2, animator.GetCurrentAnimatorStateInfo(0).length);
     }
 
     // OnStateUpdate is called on each Update frame between OnStateEnter and OnStateExit callbacks
-    override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
-    {
-        if (PlayerCombat.Instance.meleeInputReceived && !PlayerCombat.Instance.heavyHold && !animator.GetBool("isClimbing"))
-        {
-            Player.Instance.animator.Play("LAttack3");
-        }
-    }
+    //override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    //{
+ 
+    //}
 
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
     //override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)

--- a/Assets/Scripts/Player/AnimatorScripts/LTran3Script.cs
+++ b/Assets/Scripts/Player/AnimatorScripts/LTran3Script.cs
@@ -8,6 +8,8 @@ public class LTran3Script : StateMachineBehaviour
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         Player.Instance.SetCurrentState(Player.State.AttackTransition);
+
+        PlayerCombat.Instance.UpdateCombo(3, animator.GetCurrentAnimatorStateInfo(0).length);
     }
 
     // OnStateUpdate is called on each Update frame between OnStateEnter and OnStateExit callbacks

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -62,6 +62,8 @@ public class Player : MonoBehaviour
         TextStyleEnergy.fontSize = 30;
         TextStyleHealth.fontSize = 30;
         TextStyleEnergy.normal.textColor = Color.red;
+
+        //combatScript.comboTime = GetTransitionAnimTime();
     }
 
     private void FixedUpdate()
@@ -76,14 +78,34 @@ public class Player : MonoBehaviour
     // Most of the animations are started from this function some are in JumpScript, Jump animation blendtree
     private void HandleAnimations()
     {
-
         // When currentState is Idle
         if(currentState == State.Idle)
         {
-            // Player melees light attack and we arent currently climbing
-            if (PlayerCombat.Instance.meleeInputReceived && !PlayerCombat.Instance.heavyHold && !animator.GetBool("isClimbing"))
+            // Player melees light attack and we arent currently climbing and combo is not on cooldown
+            if (combatScript.meleeInputReceived && !combatScript.heavyHold && !animator.GetBool("isClimbing") && !combatScript.getComboOnCooldown())
             {
-                animator.Play("LAttack1");
+                // Combo is not active we set it to active since we attack
+                if (!combatScript.getComboActive())
+                    combatScript.setComboActive(true);
+
+                switch (combatScript.getCurrentComboIndex())
+                {
+                    case 0:
+                        animator.Play("LAttack1");       
+                        break;
+                    case 1:
+                        animator.Play("LAttack2");
+                        // Stop this for the duration of LAttack2 clip LTran2 will start timer again when clip starts
+                        combatScript.StopComboTimer();
+                        break;
+                    case 2:
+                        animator.Play("LAttack3");
+                        // Stop this so cooldown starts after LTran3 clip has "played" or should have played if we started running during the clip
+                        combatScript.StopComboTimer();
+                        break;
+                    default:
+                        break;
+                }
             }
             // Player starts moving
             if (PlayerMovement.Instance.horizontal != 0f)
@@ -106,9 +128,27 @@ public class Player : MonoBehaviour
                 animator.SetBool("isRunning", false);
             }
             // From running to Light attack
-            if (PlayerCombat.Instance.meleeInputReceived && !PlayerCombat.Instance.heavyHold && !animator.GetBool("isClimbing"))
+            if (combatScript.meleeInputReceived && !combatScript.heavyHold && !animator.GetBool("isClimbing") && !combatScript.getComboOnCooldown())
             {
-                animator.Play("LAttack1");
+                if (!combatScript.getComboActive())
+                    combatScript.setComboActive(true);
+
+                switch (combatScript.getCurrentComboIndex())
+                {
+                    case 0:
+                        animator.Play("LAttack1");
+                        break;
+                    case 1:
+                        animator.Play("LAttack2");
+                        combatScript.StopComboTimer();
+                        break;
+                    case 2:
+                        animator.Play("LAttack3");
+                        combatScript.StopComboTimer();
+                        break;
+                    default:
+                        break;
+                }
             }
             // Throw
             if (PlayerCombat.Instance.throwInputReceived)
@@ -124,6 +164,68 @@ public class Player : MonoBehaviour
             if (PlayerMovement.Instance.horizontal != 0f)
             {
                 animator.SetBool("isRunning", true);
+            }
+            // From transition to Light attack
+            if (combatScript.meleeInputReceived && !combatScript.heavyHold && !animator.GetBool("isClimbing") && !combatScript.getComboOnCooldown())
+            {
+                if (!combatScript.getComboActive())
+                    combatScript.setComboActive(true);
+
+                switch (combatScript.getCurrentComboIndex())
+                {
+                    case 0:
+                        animator.Play("LAttack1");
+                        break;
+                    case 1:
+                        animator.Play("LAttack2");
+                        combatScript.StopComboTimer();
+                        break;
+                    case 2:
+                        animator.Play("LAttack3");
+                        combatScript.StopComboTimer();
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // When the current state is Ascending or Falling
+        if (currentState == State.Ascending || currentState == State.Falling)
+        {
+            // From ascending or falling to Light attack
+            if (combatScript.meleeInputReceived && !combatScript.heavyHold && !animator.GetBool("isClimbing") && !combatScript.getComboOnCooldown())
+            {
+                if (!combatScript.getComboActive())
+                    combatScript.setComboActive(true);
+
+                switch (combatScript.getCurrentComboIndex())
+                {
+                    case 0:
+                        animator.Play("LAttack1");
+                        break;
+                    case 1:
+                        animator.Play("LAttack2");
+                        combatScript.StopComboTimer();
+                        break;
+                    case 2:
+                        animator.Play("LAttack3");
+                        combatScript.StopComboTimer();
+                        break;
+                    default:
+                        break;
+                }
+
+                //if (currentState == State.Ascending)
+                //    animator.Play("LAttack2");
+                //else if (currentState == State.Falling)
+                //    animator.Play("LAttack3");
+            }
+
+            // Throw
+            if (PlayerCombat.Instance.throwInputReceived)
+            {
+                animator.Play("Throw");
             }
         }
 
@@ -198,8 +300,22 @@ public class Player : MonoBehaviour
                 movementScript.EnableInputMove();
                 break;
             case State.Ascending:
+                // Combat
+                combatScript.EnableInputMelee();
+                combatScript.EnableInputThrowAim();
+
+                // Movement
+                movementScript.EnableInputJump();
+                movementScript.EnableInputMove();
                 break;
             case State.Falling:
+                // Combat
+                combatScript.EnableInputMelee();
+                combatScript.EnableInputThrowAim();
+
+                // Movement
+                movementScript.EnableInputJump();
+                movementScript.EnableInputMove();
                 break;
             case State.Landing:
                 // Combat
@@ -333,6 +449,17 @@ public class Player : MonoBehaviour
     public bool GetLaunching()
     {
         return animator.GetBool("isLaunching");
+    }
+
+    public float GetTransitionAnimTime()
+    {
+        AnimationClip[] clips = animator.runtimeAnimatorController.animationClips;
+        foreach (AnimationClip clip in clips)
+        {
+            if (clip.name == "LTran1")
+                return clip.length;
+        }
+        return 0f;
     }
 
     public bool IsFacingRight()

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -117,6 +117,16 @@ public class Player : MonoBehaviour
             }
         }
 
+        // When current state is attack transition
+        if(currentState == State.AttackTransition)
+        {
+            // Player starts moving
+            if (PlayerMovement.Instance.horizontal != 0f)
+            {
+                animator.SetBool("isRunning", true);
+            }
+        }
+
         // LedgeClimb animation
         // LedgeChecks return true
         if (movementScript.getClimbing() && !animator.GetBool("isAttacking") && !animator.GetBool("isAiming"))

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -516,7 +516,7 @@ public class PlayerCombat : MonoBehaviour
     // timer starts again when LTran# animation starts
     private IEnumerator ComboTimer(float transitionTime)
     {
-        yield return new WaitForSecondsRealtime(transitionTime);
+        yield return new WaitForSeconds(transitionTime);
         // If we go here we didn't melee before attack transition (if we started running transitionTime) ended
         setComboOnCooldown(true);
     }
@@ -525,7 +525,7 @@ public class PlayerCombat : MonoBehaviour
     {
         // We are on cooldown and we don not have combo active
         setComboActive(false);
-        yield return new WaitForSecondsRealtime(comboCooldownTime);
+        yield return new WaitForSeconds(comboCooldownTime);
         // Set this to false so we do not attack instatly when we com out of cooldown
         meleeInputReceived = false;
         // We did our time

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -19,6 +19,13 @@ public class PlayerCombat : MonoBehaviour
     [SerializeField] private bool kbOnLight;
     [SerializeField] private bool kbOnLightLast;
 
+    [Header("Combo Variables")]
+    private bool comboOnCooldown = false; // Boolean of active combo cooldown
+    private bool comboActive = false; // Boolean of active combo set
+    private int currentComboIndex = 0; // What hit we did last
+    private Coroutine comboTimerCoroutine; // Used to stop comboTimer for attack animation duration if we detect input
+    [SerializeField] private float comboCooldownTime; // Time between combo sets example: we hit once wait comboTimerCoroutine to finish -> ComboCooldown starts we cannot attack during this
+
     [Header("Attack Detection Variables")]
     public LayerMask enemyLayer;
     public Transform attackPoint; // Center of the hit point box we draw to check collisions
@@ -241,7 +248,7 @@ public class PlayerCombat : MonoBehaviour
 
             // Input for melee 
             // Melee type checked in Idle and transitions if heavyHold is true or false
-            else if (!throwAimHold)
+            else if (!throwAimHold && !getComboOnCooldown())
             {
                 meleeInputReceived = true;
             }
@@ -487,6 +494,76 @@ public class PlayerCombat : MonoBehaviour
         //tranToIdle = StartCoroutine(TranToIdle(3));
     }
     // ----------- PLACEHOLDER ANIMATIONS -------------------
+
+    // --- COMBO ---
+    
+    // Called from Transition animation scripts they know their attack animation and how long current transition would be
+    public void UpdateCombo(int attackIndex, float transitionTime)
+    {
+        currentComboIndex = attackIndex;
+
+        // Start timer if this runs out we go cooldown no spamming
+        comboTimerCoroutine = StartCoroutine(ComboTimer(transitionTime));
+    }
+
+    // Stops timer (kills coroutine) for until started again
+    public void StopComboTimer()
+    {
+        StopCoroutine(comboTimerCoroutine);
+    }
+
+    // Calculates time between attacks (attack transition time) if it runs out we set combo on cooldown if we melee before Player.cs calls StopComboTimer() and 
+    // timer starts again when LTran# animation starts
+    private IEnumerator ComboTimer(float transitionTime)
+    {
+        yield return new WaitForSecondsRealtime(transitionTime);
+        // If we go here we didn't melee before attack transition (if we started running transitionTime) ended
+        setComboOnCooldown(true);
+    }
+
+    private IEnumerator ComboCooldown()
+    {
+        // We are on cooldown and we don not have combo active
+        setComboActive(false);
+        yield return new WaitForSecondsRealtime(comboCooldownTime);
+        // Set this to false so we do not attack instatly when we com out of cooldown
+        meleeInputReceived = false;
+        // We did our time
+        setComboOnCooldown(false);
+        // We start from combo index 0 aka first hit of combo
+        currentComboIndex = 0;
+    }
+
+    public bool getComboOnCooldown()
+    {
+        return comboOnCooldown;
+    }
+    public void setComboOnCooldown(bool b)
+    {
+        // If we set (true) combo on cooldown start coroutine to calculate passed time
+        if (b)
+            StartCoroutine(ComboCooldown());
+
+        comboOnCooldown = b;
+    }
+
+    // Called from Player.cs
+    public bool getComboActive()
+    {
+        return comboActive;
+    }
+    public void setComboActive(bool b)
+    {
+        comboActive = b;
+    }
+
+    // Used in Player.cs HandleAnimations() to play correct attack animation
+    public int getCurrentComboIndex()
+    {
+        return currentComboIndex;
+    }
+
+    // --- DASH ---
 
     // Put these functions in PlayerMovement????
     public void AttackDash()


### PR DESCRIPTION
Combo calculations and all attack animations are started from Player.cs HandleAnimations() (old from transition scripts).
Cooldown between combo sets 0.5 second + last attacks transition (currently all transitions are 0.5 s).
 - Player cant melee if this cooldown is ongoing
Transition time calculating between attacks.
 - You can attack light 1 and run small distance and attack light 2 if you did it before transition time ended. 