### PR TITLE
Shockwave Dive - Tweaking

### DIFF
--- a/Assets/Prefabs/Boost Plant.prefab
+++ b/Assets/Prefabs/Boost Plant.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &7479057078975867349
+--- !u!1 &8810106819511228557
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,110 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7479057078975867348}
-  - component: {fileID: 7479057078975867346}
-  - component: {fileID: 7479057078975867347}
-  - component: {fileID: 7479057078975867345}
-  m_Layer: 6
-  m_Name: Boost Plant
+  - component: {fileID: 8810106819511228554}
+  - component: {fileID: 8810106819511228555}
+  - component: {fileID: 8810106819511228552}
+  m_Layer: 0
+  m_Name: LaunchCheck
   m_TagString: BoostPlant
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7479057078975867348
+--- !u!4 &8810106819511228554
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479057078975867349}
+  m_GameObject: {fileID: 8810106819511228557}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8810106819703291205}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &8810106819511228555
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8810106819511228557}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.008174896, y: 0.34334564}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.75, y: 0.3}
+  m_EdgeRadius: 0
+--- !u!114 &8810106819511228552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8810106819511228557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 356985d24493a0f4da5d1d159b3ae545, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  movementScript: {fileID: 0}
+  launchDistance: 10
+--- !u!1 &8810106819703291204
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8810106819703291205}
+  - component: {fileID: 8810106819703291203}
+  - component: {fileID: 8810106819703291202}
+  m_Layer: 0
+  m_Name: Boost Plant
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8810106819703291205
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8810106819703291204}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -17.5, y: -29.73, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 8810106819511228554}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7479057078975867346
+--- !u!212 &8810106819703291203
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479057078975867349}
+  m_GameObject: {fileID: 8810106819703291204}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -84,13 +156,13 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &7479057078975867347
+--- !u!61 &8810106819703291202
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479057078975867349}
+  m_GameObject: {fileID: 8810106819703291204}
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
@@ -110,17 +182,3 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!114 &7479057078975867345
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479057078975867349}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 356985d24493a0f4da5d1d159b3ae545, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  movementScript: {fileID: 0}
-  launchDistance: 10

--- a/Assets/Scenes/ShockwaveTool.unity
+++ b/Assets/Scenes/ShockwaveTool.unity
@@ -3007,11 +3007,11 @@ PrefabInstance:
       objectReference: {fileID: 729320505}
     - target: {fileID: 284613507, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.x
-      value: -0.9999989
+      value: -0.9999992
       objectReference: {fileID: 0}
     - target: {fileID: 284613507, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.y
-      value: -1.785265e-24
+      value: -0.00000009211864
       objectReference: {fileID: 0}
     - target: {fileID: 505850491, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_Follow
@@ -3272,7 +3272,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2646993275326716549, guid: 4154d57994558ff489a9180c3151e624, type: 3}
       propertyPath: shockwaveDiveGravityScale
-      value: 10
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 2646993275326716550, guid: 4154d57994558ff489a9180c3151e624, type: 3}
       propertyPath: m_Size.x

--- a/Assets/Scenes/ShockwaveTool.unity
+++ b/Assets/Scenes/ShockwaveTool.unity
@@ -123,130 +123,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &3218690
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3218691}
-  - component: {fileID: 3218693}
-  - component: {fileID: 3218692}
-  - component: {fileID: 3218694}
-  m_Layer: 0
-  m_Name: Boost Plant
-  m_TagString: BoostPlant
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3218691
+--- !u!4 &3218691 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+  m_PrefabInstance: {fileID: 8810106819702169670}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3218690}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -17.5, y: -29.73, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 547708081}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &3218692
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3218690}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!212 &3218693
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3218690}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 0.2958348, g: 0.5660378, b: 0.29958132, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!114 &3218694
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3218690}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 356985d24493a0f4da5d1d159b3ae545, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  movementScript: {fileID: 1155802647}
-  launchDistance: 10
 --- !u!1001 &6180978
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3126,11 +3007,11 @@ PrefabInstance:
       objectReference: {fileID: 729320505}
     - target: {fileID: 284613507, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.x
-      value: -0.9999247
+      value: -0.9999989
       objectReference: {fileID: 0}
     - target: {fileID: 284613507, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_TrackedObjectOffset.y
-      value: 0
+      value: -1.785265e-24
       objectReference: {fileID: 0}
     - target: {fileID: 505850491, guid: 3db3967e4c6dd1e4b8e81b71ffd4ac49, type: 3}
       propertyPath: m_Follow
@@ -3391,7 +3272,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2646993275326716549, guid: 4154d57994558ff489a9180c3151e624, type: 3}
       propertyPath: shockwaveDiveGravityScale
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2646993275326716550, guid: 4154d57994558ff489a9180c3151e624, type: 3}
       propertyPath: m_Size.x
@@ -3610,3 +3491,64 @@ PrefabInstance:
       objectReference: {fileID: 469019601}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: df75306e14736564696819960c37ebf1, type: 3}
+--- !u!1001 &8810106819702169670
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 547708081}
+    m_Modifications:
+    - target: {fileID: 8810106819511228552, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: movementScript
+      value: 
+      objectReference: {fileID: 1155802647}
+    - target: {fileID: 8810106819703291204, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_Name
+      value: Boost Plant
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -29.73
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8810106819703291205, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0e2f12d93683a7e4c9e2148257f60c56, type: 3}

--- a/Assets/Scripts/Equipment/ShockwaveTool.cs
+++ b/Assets/Scripts/Equipment/ShockwaveTool.cs
@@ -40,8 +40,10 @@ public class ShockwaveTool : MonoBehaviour
         shockwaveDiveGraphics.SetActive(true);
     }
 
+    // Cancel Shockwave Dive: Triggered from PlayerMovement when deactivating dive
     public void CancelShockwaveDive()
     {
+        // Set dive used to false and disable dive graphics
         ShockwaveDiveUsed = false;
         if (shockwaveDiveGraphics.activeInHierarchy)
             shockwaveDiveGraphics.SetActive(false);

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -556,8 +556,8 @@ public class Player : MonoBehaviour
         GUI.Label(new Rect(700, 10, 300, 100), "Currently: " + currentState, TextStyleHealth);
         GUI.Label(new Rect(1000, 10, 300, 100), "Previously: " + previousState, TextStyleEnergy);
 
-        //GUI.Label(new Rect(1500, 10, 300, 100), "Gravity: " + rb.gravityScale, TextStyleEnergy);
-        GUI.Label(new Rect(1500, 10, 300, 100), "Horizontal: " + movementScript.horizontal, TextStyleEnergy);
+        GUI.Label(new Rect(1500, 10, 300, 100), "Gravity: " + rb.gravityScale, TextStyleEnergy);
+        //GUI.Label(new Rect(1500, 10, 300, 100), "Horizontal: " + movementScript.horizontal, TextStyleEnergy);
     }
 
     // Move action: Called when the Move Action Button is pressed

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -556,6 +556,7 @@ public class Player : MonoBehaviour
         GUI.Label(new Rect(700, 10, 300, 100), "Currently: " + currentState, TextStyleHealth);
         GUI.Label(new Rect(1000, 10, 300, 100), "Previously: " + previousState, TextStyleEnergy);
 
+        //GUI.Label(new Rect(1500, 10, 300, 100), "Gravity: " + rb.gravityScale, TextStyleEnergy);
         GUI.Label(new Rect(1500, 10, 300, 100), "Horizontal: " + movementScript.horizontal, TextStyleEnergy);
     }
 

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -129,12 +129,7 @@ public class PlayerMovement : MonoBehaviour
 
         // Ground check to set state variables
         if (IsGrounded())
-        {
-            shockwaveTool.CancelShockwaveDive(); // Checks if shockwave dive graphics are on and disables them
-            diving = false;
             lastGroundedTime = Time.time;
-            rb.gravityScale = defaultGravityScale;
-        }
         else
             CheckIfStuck();
 
@@ -165,6 +160,7 @@ public class PlayerMovement : MonoBehaviour
         CheckLedgeClimb();
         CheckWallJump();
         CheckShockwaveJump();
+        CheckShockwaveDive();
     }
 
     // ---- INPUTS -----
@@ -241,6 +237,7 @@ public class PlayerMovement : MonoBehaviour
             // Air Dive functionality here
             shockwaveTool.DoShockwaveDive(); // Activate VFX
             rb.gravityScale = shockwaveDiveGravityScale;
+
         }
 
         // -DOUBLE JUMP-
@@ -299,6 +296,19 @@ public class PlayerMovement : MonoBehaviour
         {
             lastGroundedTime = Time.time;
             canShockwaveJump = true;
+        }
+    }
+
+    // Diving needs to be number one priority, so gravity scale stays the same throughout the whole dive until touching ground again
+    private void CheckShockwaveDive()
+    {
+        // Check if dive is in use and no longer going downwards
+        if (rb.velocity.y >= 0 && shockwaveTool.ShockwaveDiveUsed)
+        {
+            // Cancel dive
+            shockwaveTool.CancelShockwaveDive();
+            diving = false;
+            rb.gravityScale = defaultGravityScale;
         }
     }
 
@@ -400,7 +410,7 @@ public class PlayerMovement : MonoBehaviour
         }
     }
 
-    // ---- SHOCKWAWE ----
+    // ---- SHOCKWAVE ----
 
     private void CheckShockwaveJump()
     {
@@ -482,7 +492,8 @@ public class PlayerMovement : MonoBehaviour
     // Launch when player jumps on Boost Plant. Called by BoostPlant-script
     public void ActivateLaunch(float launchDist, Vector2 launchDir)
     {
-        if (Time.time - lastDiveTime <= 3)
+        rb.gravityScale = defaultGravityScale; // Reset gravity
+        if (Time.time - lastDiveTime <= 1)
         {
             // Dived, so activate higher jump
             StartCoroutine(Launch());

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -227,8 +227,7 @@ public class PlayerMovement : MonoBehaviour
         // Air dive while in the air
         else if (context.started && !IsGrounded()
             && playerScript.InputVertical == -1 // Pressing downwards
-            && (Time.time - lastLaunchTime > 0.2f || lastLaunchTime == null) // Not just launched
-            && !(Time.time - lastGroundedTime <= coyoteTime)) // No coyote jump
+            && (Time.time - lastLaunchTime > 0.2f || lastLaunchTime == null)) // Not just launched
         {
             shockwaveTool.DoShockwaveDive(); // Activate VFX
             rb.gravityScale = shockwaveDiveGravityScale;
@@ -268,7 +267,8 @@ public class PlayerMovement : MonoBehaviour
 
         // If button was pressed
         if (context.performed && (Time.time - lastGroundedTime <= coyoteTime) // Check if coyote time is online
-            && (Time.time - jumpButtonPressedTime <= coyoteTime) && !climbing) // Check if jump has been buffered
+            && (Time.time - jumpButtonPressedTime <= coyoteTime) && !climbing // Check if jump has been buffered
+            && playerScript.InputVertical != -1) // Not pressing downwards / diving
         {
             rb.velocity = new Vector2(rb.velocity.x, jumpForce); // Jump!
         }


### PR DESCRIPTION
Fixed multiple issues with shockwave dive:
- Dive didn't feel powerful enough, so increased dive gravity scale from 7 to 20 (default is 5)
- When launching, a well timed dive could get player stuck inside boost plant collider and so never launching. Fixed by disabling dive inputs for a brief moment after launching
- Coyote jumping while holding down initiated both normal jump + shockwave dive, which in turn flashed shockwave dive graphics briefly. Fixed this by checking dive when jumping so dive overrides normal jump everytime.