### PR TITLE
Dash stop with coroutine or distance traveled

### DIFF
--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -495,7 +495,14 @@ public class PlayerCombat : MonoBehaviour
         {
             posBeforeDash = transform.position;
             dash = true;
+            StartCoroutine(DashCounter(dashDistance / dashSpeed));
         }
+    }
+    // Stops applying force if max distance is not reached due collider in the way
+    IEnumerator DashCounter(float time)
+    {
+        yield return new WaitForSeconds(time);
+        dash = false;
     }
     private void CheckAttackDashDistance()
     {
@@ -508,7 +515,7 @@ public class PlayerCombat : MonoBehaviour
         // Dash needs continuous input since inactive
         else if (dash)
         {
-            rb.velocity = new Vector2(transform.localScale.x, 0f) * dashSpeed;
+            rb.velocity = new Vector2(transform.localScale.x * dashSpeed, rb.velocity.y);
         }
     }
 


### PR DESCRIPTION
Stops dash when maxDistance is reached or when time it would take to reach that distance with dashSpeed (t = x / v).
Remove stopping in air when meleed. NOW takes rb current velocity.y instead set it to 0.
Feels and looks like player jumps higher when melee just after jumping but it doesn't (y position checked and tested).