### PR TITLE
Ground Enemy - Sorting Layer Tweak

### DIFF
--- a/Assets/Prefabs/Enemies/Small enemies/GroundEnemyOne.prefab
+++ b/Assets/Prefabs/Enemies/Small enemies/GroundEnemyOne.prefab
@@ -273,8 +273,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -2065794617
+  m_SortingLayer: 4
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 84999fc189417084e833565d04c1b244, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}


### PR DESCRIPTION
Updated ground enemy sorting layer from Default to Objects so it now correctly renders on top of interiors.